### PR TITLE
Enable GitHub Actions workflow execution

### DIFF
--- a/.github/workflows/test-actions.yml
+++ b/.github/workflows/test-actions.yml
@@ -1,0 +1,22 @@
+name: Test Actions
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Verify workflows are accessible
+        run: |
+          echo "GitHub Actions is enabled and working!"
+          echo "Available workflows:"
+          echo "- Check for New RustNet Release (Manual & Scheduled)"
+          echo "- Update RustNet Package (Manual)"
+          echo "- Publish to Chocolatey (Manual & on Release)"


### PR DESCRIPTION
This workflow will:
- Trigger on push to main to activate the Actions tab
- Be manually runnable from the GitHub UI
- Make all other workflows visible in the Actions interface

All workflows now have workflow_dispatch triggers for manual execution.