### PR TITLE
fix: don't wipe tools/ on upgrade

### DIFF
--- a/.github/workflows/update-package.yml
+++ b/.github/workflows/update-package.yml
@@ -153,19 +153,52 @@ jobs:
           $nupkg = Get-ChildItem *.nupkg | Select-Object -First 1
           Write-Host "Built package: $($nupkg.Name)"
 
-      - name: Test package installation
+      - name: Test package installation (clean install)
         if: steps.check.outputs.needs_update == 'true'
         shell: pwsh
         run: |
           choco install rustnet -source "'.;https://community.chocolatey.org/api/v2/'" -y
 
-          if (Get-Command rustnet -ErrorAction SilentlyContinue) {
-            Write-Host "Package installed successfully"
-            Write-Host "Note: Skipping version check (requires Npcap Runtime)"
-          } else {
-            Write-Error "Package installation failed"
+          if (-not (Get-Command rustnet -ErrorAction SilentlyContinue)) {
+            Write-Error "Package installation failed: rustnet not on PATH"
             exit 1
           }
+          $exe = "C:\ProgramData\chocolatey\lib\rustnet\tools\rustnet.exe"
+          if (-not (Test-Path $exe)) {
+            Write-Error "Clean install: rustnet.exe missing at $exe"
+            exit 1
+          }
+          Write-Host "Clean install OK (rustnet.exe present in tools/)"
+
+          choco uninstall rustnet -y
+
+      - name: Test package upgrade from previously-published version
+        if: steps.check.outputs.needs_update == 'true'
+        shell: pwsh
+        run: |
+          # Install the latest version currently on the community feed,
+          # then upgrade to the locally-built package. This catches the
+          # class of bug where leftover files from the previous install
+          # confuse the new install script (regression for the
+          # tools/-wipe bug fixed in 1.3.0.1).
+          choco install rustnet --source 'https://community.chocolatey.org/api/v2/' -y
+          if (-not (Test-Path 'C:\ProgramData\chocolatey\lib\rustnet\tools\rustnet.exe')) {
+            Write-Error "Setup failure: previously-published rustnet did not install cleanly"
+            exit 1
+          }
+
+          choco upgrade rustnet --source "'.;https://community.chocolatey.org/api/v2/'" -y --force
+
+          $exe = "C:\ProgramData\chocolatey\lib\rustnet\tools\rustnet.exe"
+          if (-not (Test-Path $exe)) {
+            Write-Error "Upgrade install: rustnet.exe missing at $exe (regression of tools/-wipe bug)"
+            exit 1
+          }
+          if (-not (Get-Command rustnet -ErrorAction SilentlyContinue)) {
+            Write-Error "Upgrade install: rustnet not on PATH"
+            exit 1
+          }
+          Write-Host "Upgrade install OK (rustnet.exe still present after upgrade)"
 
           choco uninstall rustnet -y
 

--- a/rustnet.nuspec
+++ b/rustnet.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>rustnet</id>
-    <version>1.3.0</version>
+    <version>1.3.0.1</version>
     <packageSourceUrl>https://github.com/domcyrus/rustnet-chocolatey</packageSourceUrl>
     <owners>domcyrus</owners>
     <title>RustNet</title>

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -25,6 +25,13 @@ if (-not $npcapInstalled) {
     Write-Host ""
 }
 
+# On upgrade, Chocolatey restores the previous install's files into
+# $toolsDir before running this script. Those leftovers (a stale
+# rustnet.exe at the root and an assets\ folder) would poison the
+# recursive search below and cause the cleanup step to wipe $toolsDir.
+# Strip everything except the install/uninstall scripts before extracting.
+Get-ChildItem -Path $toolsDir -Force -Exclude 'chocolatey*.ps1' | Remove-Item -Recurse -Force
+
 $packageArgs = @{
   packageName    = $packageName
   unzipLocation  = $toolsDir
@@ -33,28 +40,30 @@ $packageArgs = @{
   checksumType64 = $checksumType64
 }
 
-# Download and extract the archive
 Install-ChocolateyZipPackage @packageArgs
 
-# Find the executable (it's inside a versioned folder)
-$extractedExe = Get-ChildItem -Path $toolsDir -Filter 'rustnet.exe' -Recurse | Select-Object -First 1
-
-# Verify the executable exists
-if (-not $extractedExe) {
-  throw "RustNet executable not found in $toolsDir"
+# The archive always extracts a single versioned subfolder. Match it
+# directly instead of recursively hunting for rustnet.exe — a recursive
+# search can match a leftover file at the tools root and turn the
+# cleanup below into a recursive delete of $toolsDir itself.
+$extractedDir = Get-ChildItem -Path $toolsDir -Directory -Filter 'rustnet-v*-pc-windows-msvc' | Select-Object -First 1
+if (-not $extractedDir) {
+  throw "Expected versioned subfolder (rustnet-v*-pc-windows-msvc) not found in $toolsDir after extraction"
+}
+if ($extractedDir.FullName -eq $toolsDir) {
+  throw "Refusing to operate: extracted directory resolved to `$toolsDir itself"
+}
+$exeSource = Join-Path $extractedDir.FullName 'rustnet.exe'
+if (-not (Test-Path $exeSource)) {
+  throw "rustnet.exe not found in extracted archive at $exeSource"
 }
 
-# Move executable and assets to tools directory root
-$extractedDir = $extractedExe.Directory.FullName
-Move-Item -Path (Join-Path $extractedDir 'rustnet.exe') -Destination $toolsDir -Force
-if (Test-Path (Join-Path $extractedDir 'assets')) {
-  Move-Item -Path (Join-Path $extractedDir 'assets') -Destination $toolsDir -Force
+Move-Item -Path $exeSource -Destination $toolsDir -Force
+if (Test-Path (Join-Path $extractedDir.FullName 'assets')) {
+  Move-Item -Path (Join-Path $extractedDir.FullName 'assets') -Destination $toolsDir -Force
 }
 
-# Clean up extracted folder
-Remove-Item -Path $extractedDir -Recurse -Force -ErrorAction SilentlyContinue
-
-$exePath = Join-Path $toolsDir 'rustnet.exe'
+Remove-Item -Path $extractedDir.FullName -Recurse -Force
 
 Write-Host "RustNet has been installed successfully!" -ForegroundColor Green
 Write-Host ""


### PR DESCRIPTION
Match the versioned subfolder by name and scrub stale files before extraction so a leftover rustnet.exe at tools/ root no longer makes $extractedDir resolve to $toolsDir and get recursively deleted. Bump to 1.3.0.1 and add upgrade-path CI test.